### PR TITLE
Update gemspec to allow redis gem version 4.x

### DIFF
--- a/redis_reliable_queue.gemspec
+++ b/redis_reliable_queue.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'redis', '~> 3.2'
+  s.add_runtime_dependency 'redis', '>= 3.2', '< 5.0'
 
   s.add_development_dependency 'pry-doc'
   s.add_development_dependency 'rspec', '~> 2.13', '>= 2.13.0'


### PR DESCRIPTION
But not 5.x, because it doesn't exist yet!